### PR TITLE
Fix RangeError maximum call stack exceed

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1490,7 +1490,17 @@ function decodeClientPayload(payload) {
 	/*
 	Special function which Client using to "encode" clients JSON payload
 	*/
+	
+	/* 
+	FIX: RangeError maximum stack call exceed
+	SEE: https://stackoverflow.com/questions/8936984/uint8array-to-string-in-javascript
+	*/
+	let decoded = new TextDecoder().decode(new Uint8Array(payload))
+	return JSON.parse(decoded);
+	
+	/* LEGACY CODE
 	return JSON.parse(String.fromCharCode.apply(null, payload));
+	*/
 }
 
 function getAppState(jar) {


### PR DESCRIPTION
I noticed that the client cannot handle too much arguments and yet leads to a `RangeError` which eventually stops the listening process, So i fixed it through some help with expertise.

See [Reference](https://stackoverflow.com/questions/22123769/rangeerror-maximum-call-stack-size-exceeded-why) & [Reference](https://stackoverflow.com/questions/8936984/uint8array-to-string-in-javascript)